### PR TITLE
Add support for WordPress 6.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: wordpressdotorg, Otto42, dd32, westi, dllh
 Tags: tumblr, import
 Requires at least: 3.2
-Tested up to: 6.0
-Stable tag: 0.9
+Tested up to: 6.1
+Stable tag: 1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -25,11 +25,14 @@ Imports a Tumblr blog into a WordPress blog.
 
 == Upgrade Notice ==
 
-Version 0.9 Removes untested warning for the plugin. 
+Version 0.9 Removes untested warning for the plugin.
 
 == Changelog ==
 
-= 0.9 = 
+= 1.0 =
+* Add support for WordPress 6.1.
+
+= 0.9 =
 * Force WP_IMPORTING to true during the do_blog_import process.
 
 = 0.8 =
@@ -55,13 +58,13 @@ Version 0.9 Removes untested warning for the plugin.
 * Import Media to server (Images, Audio, Custom uploaded Video's)
 * Set the date on Media imports for easier management
 
-= 0.3 = 
+= 0.3 =
 * Handle multi-image posts
 * Handle question/answer posts
 * Handle video posts somewhat better
 * Speedup (reduce importer delay from 3 minutes to 1 minute)
 
-= 0.2 = 
+= 0.2 =
 * The audio, video, and image formats no longer use the caption for the titles. Tumblr seems to facilitate putting all sorts of crazy stuff into the caption fields as part of their reblogging system. So instead, these types of posts will have no titles at all. Sorry, but Tumblr simply doesn't have any sort of title fields here to work with, and no data that can be used to "create" a title for them.
 * Minor debug error cleanup.
 * Sideloading now done on drafts and pages as well.

--- a/tumblr-importer.php
+++ b/tumblr-importer.php
@@ -222,7 +222,7 @@ class Tumblr_Import extends WP_Importer_Cron {
 		?>
 		<div class='wrap'>
 		<?php
-		if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+		if ( version_compare( get_bloginfo( 'version' ), '3.8.0', '<' ) ) {
 			screen_icon();
 		}
 		?>

--- a/tumblr-importer.php
+++ b/tumblr-importer.php
@@ -218,7 +218,7 @@ class Tumblr_Import extends WP_Importer_Cron {
 		if ( !empty( $error ) )
 			echo "<div class='error'><p>{$error}</p></div>";
 
-		$authors = get_users( version_compare(get_bloginfo('version'), '5.9.0', '<') ? array('who' => 'authors') : array('capability' => 'edit_posts') );
+		$authors = get_users( version_compare( get_bloginfo( 'version'), '5.9.0', '<' ) ? array( 'who' => 'authors' ) : array( 'capability' => 'edit_posts' ) );
 		?>
 		<div class='wrap'>
 		<?php

--- a/tumblr-importer.php
+++ b/tumblr-importer.php
@@ -982,7 +982,7 @@ class Tumblr_Import extends WP_Importer_Cron {
 	 * Here we override the default behavior.
 	 */
 	function filter_allow_empty_content( $maybe_empty, $_post ) {
-		if ( 'gallery' == $_post['format'] )
+		if ( ! empty( $_post['format'] ) && 'gallery' == $_post['format'] )
 			return false;
 
 		return $maybe_empty;

--- a/tumblr-importer.php
+++ b/tumblr-importer.php
@@ -218,9 +218,14 @@ class Tumblr_Import extends WP_Importer_Cron {
 		if ( !empty( $error ) )
 			echo "<div class='error'><p>{$error}</p></div>";
 
-		$authors = get_users( array('who' => 'authors') );
+		$authors = get_users( version_compare(get_bloginfo('version'), '5.9.0', '<') ? array('who' => 'authors') : array('capability' => 'edit_posts') );
 		?>
-		<div class='wrap'><?php echo screen_icon(); ?>
+		<div class='wrap'>
+		<?php
+		if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+			screen_icon();
+		}
+		?>
 		<h2><?php _e('Import Tumblr', 'tumblr-importer'); ?></h2>
 		<p><?php _e('Please select the Tumblr blog you would like to import into your WordPress site and then click on the "Import this Blog" button to continue.'); ?></p>
 		<p><?php _e('If your import gets stuck for a long time or you would like to import from a different Tumblr account instead then click on the "Clear account information" button below to reset the importer.','tumblr-importer'); ?></p>

--- a/tumblr-importer.php
+++ b/tumblr-importer.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/tumblr-importer/
 Description: Import posts from a Tumblr blog.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 0.9
+Version: 1.0
 License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: tumblr-importer
 Domain Path: /languages

--- a/tumblr-importer.php
+++ b/tumblr-importer.php
@@ -102,12 +102,16 @@ class Tumblr_Import extends WP_Importer_Cron {
 	}
 
 	function greet($error=null) {
-
 		if ( !empty( $error ) )
 			echo "<div class='error'><p>{$error}</p></div>";
 		?>
 
-		<div class='wrap'><?php echo screen_icon(); ?>
+		<div class='wrap'>
+		<?php
+		if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+			screen_icon();
+		}
+		?>
 		<h2><?php _e('Import Tumblr', 'tumblr-importer'); ?></h2>
 		<?php if ( empty($this->request_tokens) ) { ?>
 		<p><?php _e('Howdy! This importer allows you to import posts from your Tumblr account into your WordPress site.', 'tumblr-importer'); ?></p>

--- a/tumblr-importer.php
+++ b/tumblr-importer.php
@@ -108,7 +108,7 @@ class Tumblr_Import extends WP_Importer_Cron {
 
 		<div class='wrap'>
 		<?php
-		if ( version_compare(get_bloginfo('version'), '3.8.0', '<') ) {
+		if ( version_compare( get_bloginfo( 'version' ), '3.8.0', '<' ) ) {
 			screen_icon();
 		}
 		?>

--- a/tumblr-importer.php
+++ b/tumblr-importer.php
@@ -58,10 +58,13 @@ class Tumblr_Import extends WP_Importer_Cron {
 
 	// Figures out what to do, then does it.
 	function start() {
-		if ( isset($_POST['restart']) )
+		if ( isset($_POST['restart']) ) {
 			$this->restart();
+		}
 
-		if ( !isset($this->error) ) $this->error = null;
+		if ( !isset($this->error) ) {
+			$this->error = null;
+		}
 
 		@ $this->consumerkey = defined ('TUMBLR_CONSUMER_KEY') ? TUMBLR_CONSUMER_KEY : ( !empty($_POST['consumerkey']) ? $_POST['consumerkey'] : $this->consumerkey );
 		@ $this->secretkey = defined ('TUMBLR_SECRET_KEY') ? TUMBLR_SECRET_KEY : ( !empty($_POST['secretkey']) ? $_POST['secretkey'] : $this->secretkey );
@@ -85,7 +88,11 @@ class Tumblr_Import extends WP_Importer_Cron {
 
 		unset ($this->error);
 
-		if ( !isset($_POST['restart']) ) $saved = $this->save_vars();
+		$saved = false;
+
+		if ( !isset($_POST['restart']) ) {
+			$saved = $this->save_vars();
+		}
 
 		if ( $saved && !isset($_GET['noheader']) ) {
 			?>

--- a/tumblr-importer.php
+++ b/tumblr-importer.php
@@ -218,7 +218,7 @@ class Tumblr_Import extends WP_Importer_Cron {
 		if ( !empty( $error ) )
 			echo "<div class='error'><p>{$error}</p></div>";
 
-		$authors = get_users( version_compare( get_bloginfo( 'version'), '5.9.0', '<' ) ? array( 'who' => 'authors' ) : array( 'capability' => 'edit_posts' ) );
+		$authors = get_users( version_compare( get_bloginfo( 'version' ), '5.9.0', '<' ) ? array( 'who' => 'authors' ) : array( 'capability' => 'edit_posts' ) );
 		?>
 		<div class='wrap'>
 		<?php


### PR DESCRIPTION
This PR adds support for WordPress 6.1 and upgrades the plugin to 1.0.

1. Tested with WordPress `6.1`
2. Tested with PHP `7.4.33`
3. The `screen_icon` function is now deprecated. Added a check for WordPress 3.8.0
4. The `who` parameter sent to `WP_User_Query` is now deprecated. Added a check for WordPress >= 5.9.0

How to test:
1. Clone the plugin
2. Spin a new docker image[^1]
3. Substitute `YOUR_FOLDER` with the path of the cloned plugin
4. Go to `http://localhost/wp-admin/plugins.php` and activate **Tumblr Importer**
5. Open `http://localhost/wp-admin/admin.php?import=tumblr`
6. You need a Tumblr account with various contents
7. You need to create a Tumblr application, follow the instructions
8. Import the content; it **can take a while** if you have a lot of content. If the script timeout, you need to `set_time_limit` to a higher value
9. The plugin must load correctly, and no errors displayed

[^1]: `docker-compose.yml` file
```yaml
services:
  db:
    image: mariadb:latest
    command: '--default-authentication-plugin=mysql_native_password'
    volumes:
      - db_data:/var/lib/mysql
    restart: always
    environment:
      - MYSQL_ROOT_PASSWORD=somewordpress
      - MYSQL_DATABASE=wordpress
      - MYSQL_USER=wordpress
      - MYSQL_PASSWORD=wordpress
    expose:
      - 3306
      - 33060
  wordpress:
    image: wordpress:latest
    volumes:
      - wp_data:/var/www/html
      - YOUR_FOLDER:/var/www/html/wp-content/plugins/tumblr-importer
    ports:
      - 80:80
    restart: always
    environment:
      - WORDPRESS_DB_HOST=db
      - WORDPRESS_DB_USER=wordpress
      - WORDPRESS_DB_PASSWORD=wordpress
      - WORDPRESS_DB_NAME=wordpress
      - WORDPRESS_DEBUG=1
volumes:
  db_data:
  wp_data:
```
