### PR TITLE
Fix custom domains error for new Tumblr blogs

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,9 @@ Version 0.9 Removes untested warning for the plugin.
 
 == Changelog ==
 
+= Unreleased =
+* Fix Tumblr bug with custom domains
+
 = 1.0 =
 * Add support for WordPress 6.1.
 


### PR DESCRIPTION
Tumblr is returning (for new blogs) the blog url like: `https://tumblr.com/blog/view/<name>` and this breaks API calls and the custom domain detection. This is fixed in this PR.

To test:

1. Go to the importer and enter credentials for a new app created **for a new Tumblr account**. Old Tumblr accounts still work fine. Connect to that account.
2. Make sure the URL is displayed like: `<name>.tumblr.com` and not `https://tumblr.com/blog/view/<name>`
3. Click import this blog and make sure the blog imports ok.

Tumblr imports are best tested in a hosted environment, so compress this branch to a ZIP and upload this as a plugin to a for e.g. JN site to test.

This PR does not update the version, that can be done in a separate diff.