### PR TITLE
Testing plugin up to WordPress 6.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: wordpressdotorg, Otto42, dd32, westi, dllh
 Tags: tumblr, import
 Requires at least: 3.2
-Tested up to: 6.1
-Stable tag: 1.0
+Tested up to: 6.2
+Stable tag: 1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -29,7 +29,8 @@ Version 0.9 Removes untested warning for the plugin.
 
 == Changelog ==
 
-= Unreleased =
+= 1.1 =
+* Testing the plugin up to WordPress 6.2
 * Fix Tumblr bug with custom domains
 
 = 1.0 =

--- a/tumblr-importer.php
+++ b/tumblr-importer.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/tumblr-importer/
 Description: Import posts from a Tumblr blog.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 1.0
+Version: 1.1
 License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: tumblr-importer
 Domain Path: /languages


### PR DESCRIPTION
This PR adds support for WordPress 6.2 and upgrades the plugin to 1.1. 
In this PR we also porting the changes from wpcom to handle custom domain issue.

Tested with WordPress 6.2
Tested with PHP 7.4.33
How to test:

- Since Tumblr requires an OAuth app connection it's better to test it using a JN site
- Clone this plugin and compress it as a zip file
- Navigate to Plugins > Add new > Upload plugin and upload it
- Navigate to `https://your-domain/wp-admin/admin.php?import=tumblr` and follow the instructions to perform an import
- Import the content; it can take a while if you have a lot of content. If the script timeout, you need to set_time_limit to a higher value
- Check and see if the import works fine without errors