### PR TITLE
Test plugin for WordPress 6.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wordpressdotorg, Otto42, dd32, westi, dllh
 Tags: tumblr, import
 Requires at least: 3.2
 Tested up to: 6.3
-Stable tag: 1.2
+Stable tag: 1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,9 +28,6 @@ Imports a Tumblr blog into a WordPress blog.
 Version 0.9 Removes untested warning for the plugin.
 
 == Changelog ==
-
-= 1.2 =
-* Testing the plugin up to WordPress 6.3
 
 = 1.1 =
 * Testing the plugin up to WordPress 6.2

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: wordpressdotorg, Otto42, dd32, westi, dllh
 Tags: tumblr, import
 Requires at least: 3.2
-Tested up to: 6.2
-Stable tag: 1.1
+Tested up to: 6.3
+Stable tag: 1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -28,6 +28,9 @@ Imports a Tumblr blog into a WordPress blog.
 Version 0.9 Removes untested warning for the plugin.
 
 == Changelog ==
+
+= 1.2 =
+* Testing the plugin up to WordPress 6.3
 
 = 1.1 =
 * Testing the plugin up to WordPress 6.2

--- a/tumblr-importer.php
+++ b/tumblr-importer.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/tumblr-importer/
 Description: Import posts from a Tumblr blog.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 1.2
+Version: 1.1
 License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: tumblr-importer
 Domain Path: /languages

--- a/tumblr-importer.php
+++ b/tumblr-importer.php
@@ -5,7 +5,7 @@ Plugin URI: http://wordpress.org/extend/plugins/tumblr-importer/
 Description: Import posts from a Tumblr blog.
 Author: wordpressdotorg
 Author URI: http://wordpress.org/
-Version: 1.1
+Version: 1.2
 License: GPL v2 - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Text Domain: tumblr-importer
 Domain Path: /languages


### PR DESCRIPTION
In this PR, we test the plugin for WordPress 6.3.

## How to test

1. Clone this PR
2. Using `wp-env` run an instance. The minimum PHP version is 7.0 because WordPress 6.3 [dropped support for PHP 5](https://make.wordpress.org/core/2023/07/05/dropping-support-for-php-5/).
3. Go to Tumblr [OAuth apps](https://www.tumblr.com/oauth/apps) and create a new app for `http://localhost:8888` or create a JN site.
4. Go to `http://localhost:8888/wp-admin/admin.php?import=tumblr` and insert the OAuth key/secret. Start the import. If the script timeout, you need to `set_time_limit` to a higher value.
5. Check if the content has been imported and no errors are being generated.