### PR TITLE
Check for rate limiting while fetching posts

### DIFF
--- a/tumblr-importer.php
+++ b/tumblr-importer.php
@@ -819,6 +819,10 @@ class Tumblr_Import extends WP_Importer_Cron {
 		switch ( $response->meta->status ) {
 			case 200: // OK
 				break;
+			case 420: // rate limited
+			case 429: // rate limited
+				// make this chill for a minute
+				return false;
 			default:
 				$_error = sprintf( __( 'Tumblr replied with an error: %s', 'tumblr-importer' ), $response->meta->msg );
 				do_action( 'tumblr_importer_handle_error', 'response_' . $response->meta->status );


### PR DESCRIPTION
If you're trying to import posts from a blog that has thousands of posts, you will quickly hit the rate limit. I think this should make the importer chill and wait for the next minute to try again?

cc @pento 