### PR TITLE
Test plugin for WordPress 6.4.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg, Otto42, dd32, westi, dllh
 Tags: tumblr, import
 Requires at least: 3.2
-Tested up to: 6.3
+Tested up to: 6.4.2
 Stable tag: 1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
- This PR updates the `Tested up to` label to WordPress 6.4.2
- Tested with WordPress 6.4.2 under PHP 7.4, PHP 8.0 and PHP 8.1


How to test:

- Clone this PR
- Using `wp-env` to test it, you can specify different PHP versions. 
- Go to Tumblr [OAuth apps](https://www.tumblr.com/oauth/apps) and create a new app for http://localhost:8881 or create a JN site.
- Go to http://localhost:8881/wp-admin/admin.php?import=tumblr and insert the OAuth key/secret. Start the import. If the script timeout, you need to set_time_limit to a higher value.
- Check if the content has been imported and no errors are being generated.
- Check and see if the import works fine without errors