### PR TITLE
Update tested up to label

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg, Otto42, dd32, westi, dllh
 Tags: tumblr, import
 Requires at least: 3.2
-Tested up to: 6.4.2
+Tested up to: 6.7
 Stable tag: 1.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
This PR updates the `Tested up to` label to WordPress 6.7-beta2.

Tested with WordPress 6.6.2 and 6.7-beta2
Tested with PHP `7.0`, `7.4`, `8.0`, `8.2`, `8.3`

How to test:
1. Clone the plugin under your working directory
2. Using `wp-env` to test, if you haven't installed it, please visit [wp-env](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/#quick-tldr-instructions) for instructions
It'll be easier to have a `.wp-env.json` file in the root folder. For example, if your root folder is tumblr-importer, you can clone the plugin under this folder. Create a `.wp-env.json` file; you can change the PHP version to the one you want to test with.
```json
{
  "phpVersion": "7.4",
  "plugins": ["./tumblr-importer"]
}
```
Run `wp-env start` to spin up the WordPress. (To select 6.7 beta add `"core": "WordPress/WordPress#master",` to your son file.)

Go to https://www.tumblr.com/oauth/apps and create an app for http://localhost:8888
Navigate to `http://localhost:8888/wp-admin/admin.php?import=tumblr` and insert OAuth key and secret.

Just to remind you, the importer is a CRON script and can take several minutes to complete.