### PR TITLE
fix warning when hit clear account information

### DIFF
--- a/class-tumblr-import.php
+++ b/class-tumblr-import.php
@@ -13,6 +13,20 @@ if ( class_exists( 'WP_Importer_Cron' ) ) {
 	class Tumblr_Import extends WP_Importer_Cron {
 
 		/**
+		 * Consumer key for Tumblr API
+		 *
+		 * @var string
+		 */
+		public $consumerkey = '';
+
+		/**
+		 * Secret key for Tumblr API
+		 *
+		 * @var string
+		 */
+		public $secretkey = '';
+
+		/**
 		 * List of duplicate posts
 		 *
 		 * @var array


### PR DESCRIPTION
### what/why

this PR fix a warning message when clicking 'Clear account information' is hit.

```
Warning: Undefined property: Tumblr_Import::$consumerkey in /var/www/html/wp-content/plugins/tumblr-importer/class-tumblr-import.php on line 64

Warning: Undefined property: Tumblr_Import::$secretkey in /var/www/html/wp-content/plugins/tumblr-importer/class-tumblr-import.php on line 65
```

### testing steps

Current behavior on trunk
1. add account information
2. hit 'Clear account information' button
3. A warning message is shown

Check this branch
1. add account information
2. hit 'Clear account information' button
3. No warning message should appear