### PR TITLE
Fix extendability access points for overwriting pieces of the importer

### DIFF
--- a/src/class-tumblr-import.php
+++ b/src/class-tumblr-import.php
@@ -53,7 +53,7 @@ class Tumblr_Import extends WP_Importer_Cron {
 
 		parent::__construct();
 
-		add_action( 'tumblr_importer_import_instructions', array( $this, 'instructions' ) );
+		add_filter( 'tumblr_importer_import_instructions', array( $this, 'instructions' ) );
 
 		$this->tumblr_importer_init();
 	}
@@ -311,7 +311,7 @@ class Tumblr_Import extends WP_Importer_Cron {
 		}
 
 		$output .= '<h2>' . esc_html__( 'Import Tumblr', 'tumblr-importer' ) . '</h2>';
-		$output .= do_action( 'tumblr_importer_import_instructions' );
+		$output .= apply_filters( 'tumblr_importer_import_instructions', '' );
 
 		if ( 1 < count( $authors ) ) {
 			$output .= '<p>' . esc_html__( 'As Tumblr does not expose the "author", even from multi-author blogs you will need to select which WordPress user will be listed as the author of the imported posts.', 'tumblr-importer' ) . '</p>';

--- a/src/class-wp-importer-cron.php
+++ b/src/class-wp-importer-cron.php
@@ -11,9 +11,9 @@ use WP_Importer;
 
 defined( 'ABSPATH' ) || exit;
 
-if ( class_exists( 'WP_Importer_Cron' ) ) :
+if ( class_exists( 'WP_Importer_Cron' ) ) {
 	return;
-endif;
+}
 
 class WP_Importer_Cron extends WP_Importer {
 

--- a/src/class-wp-importer-cron.php
+++ b/src/class-wp-importer-cron.php
@@ -11,6 +11,10 @@ use WP_Importer;
 
 defined( 'ABSPATH' ) || exit;
 
+if ( class_exists( 'WP_Importer_Cron' ) ) :
+	return;
+endif;
+
 class WP_Importer_Cron extends WP_Importer {
 
 	/**


### PR DESCRIPTION
## What/Why

When we changed a few functions to return information instead of echoing it to the screen (https://github.com/WordPress/tumblr-importer/pull/14), it broke compatibility with WordPress.com's overwriting of certain pieces.

## Testing

* Run a smoke test import locally, I'll be updating the WordPress.com patch shortly