### PR TITLE
Prep Release 1.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -29,6 +29,10 @@ Version 0.9 Removes untested warning for the plugin.
 
 == Changelog ==
 
+= 1.2 =
+* Added queued post support
+* Made the importer more extendable with new hooks and filters
+
 = 1.1 =
 * Testing the plugin up to WordPress 6.2
 * Fix Tumblr bug with custom domains

--- a/src/class-tumblr-import.php
+++ b/src/class-tumblr-import.php
@@ -323,7 +323,6 @@ class Tumblr_Import extends WP_Importer_Cron {
 		$output .= '<th>' . esc_html__( 'Posts Imported', 'tumblr-importer' ) . '</th>';
 		$output .= '<th>' . esc_html__( 'Drafts Imported', 'tumblr-importer' ) . '</th>';
 		$output .= '<th>' . esc_html__( 'Queued Imported', 'tumblr-importer' ) . '</th>';
-		$output .= '<th>' . esc_html__( 'Pages Imported', 'tumblr-importer' ) . '</th>';
 		$output .= '<th>' . esc_html__( 'Author', 'tumblr-importer' ) . '</th>';
 		$output .= '<th>' . esc_html__( 'Action/Status', 'tumblr-importer' ) . '</th>';
 		$output .= '</tr></thead><tbody>';
@@ -389,7 +388,6 @@ class Tumblr_Import extends WP_Importer_Cron {
 			$output .= '<td>' . esc_html( $this->blog[ $url ]['posts_complete'] . ' / ' . $this->blog[ $url ]['total_posts'] ) . '</td>';
 			$output .= '<td>' . esc_html( $this->blog[ $url ]['drafts_complete'] . ' / ' . $this->blog[ $url ]['total_drafts'] ) . '</td>';
 			$output .= '<td>' . esc_html( $this->blog[ $url ]['queued_complete'] . ' / ' . $this->blog[ $url ]['total_queued'] ) . '</td>';
-			$output .= '<td>' . esc_html( $this->blog[ $url ]['pages_complete'] ) . '</td>';
 			$output .= '<td>' . $author_selection . '</td>';
 			$output .= '<td>' . $submit . '</td>';
 			$output .= '</form></tr>';


### PR DESCRIPTION
This PR adds some release notes for 1.2 to the README. It does not bump the stable tag yet.

It does not include pages support yet, since the Tumblr API doesn't have it yet.