### PR TITLE
add global configs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,12 @@ jobs:
       uses: actions/checkout@v4
     - name: Build
       # 10up/action-wordpress-plugin-deploy is not adding the vendor folder due to .gitignore so we need to add it manually
+      # also uses their user to commit the vendor folder
+      # https://github.com/10up/action-wordpress-plugin-deploy/blob/408b966c84f07de4f648a0fd04f103ba72b18590/deploy.sh#L113
       run: |
         composer install --no-dev --optimize-autoloader
+        git config --global user.email "10upbot+github@10up.com"
+        git config --global user.name "10upbot on GitHub"
         git add -f vendor && git commit -m "Add vendor folder"
     - name: WordPress Plugin Deploy
       uses: 10up/action-wordpress-plugin-deploy@stable


### PR DESCRIPTION
### what/why

this [job](https://github.com/WordPress/tumblr-importer/actions/runs/12298824360/job/34323131667) failed missing user and email git global configs, this commit adds them. btw, this is using the same user and email that the 10up action uses.